### PR TITLE
DMFT Client with Justin Claim, Client role etc

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ What is the context for those changes? For example: particular role needs to be 
 - [ ] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
 - [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
 - [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
-- [ ] [CMDB](https://cmdb.hlth.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
+- [ ] [CMDB](https://servicenow.justice.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
 - [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]
 
 [^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.

--- a/common-sso-dev/main.tf
+++ b/common-sso-dev/main.tf
@@ -8,7 +8,8 @@ terraform {
 }
 
 module "ISB" {
-  source = "./realms/isb"
+  source           = "./realms/isb"
+  client_auth_pass = var.client_auth_pass
 }
 
 provider "keycloak" {

--- a/common-sso-dev/realms/isb/variables.tf
+++ b/common-sso-dev/realms/isb/variables.tf
@@ -1,4 +1,4 @@
 variable "client_auth_pass" {
-  type    = string
-  default = "default_value" # Set a default value or replace with your actual default value
+  type = string
+  //default = "default_value" # Set a default value or replace with your actual default value
 }

--- a/common-sso-dev/variables.tf
+++ b/common-sso-dev/variables.tf
@@ -9,3 +9,7 @@ variable "client_secret" {
 variable "keycloak_url" {
   description = "The URL of the Keycloak instance"
 }
+variable "client_auth_pass" {
+  type = string
+  //default = "default_value" # Set a default value or replace with your actual default value
+}

--- a/main.tf
+++ b/main.tf
@@ -28,9 +28,10 @@ module "COMMON_SSO_DEV" {
   source = "./common-sso-dev"
 
 
-  client_id     = var.dev_client_id
-  client_secret = var.dev_client_secret
-  keycloak_url  = var.dev_keycloak_url
+  client_id        = var.dev_client_id
+  client_secret    = var.dev_client_secret
+  keycloak_url     = var.dev_keycloak_url
+  client_auth_pass = var.client_auth_pass
 }
 
 # module "COMMON_SSO_TEST" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,10 @@ variable "dev_keycloak_url" {
   description = "The URL of the Keycloak instance"
   default     = "https://sso-e27db1-dev.apps.gold.devops.gov.bc.ca/auth"
 }
-
-
+variable "client_auth_pass" {
+  type = string
+  //default = "default_value" # Set a default value or replace with your actual default value
+}
 # # KEYCLOAK_TEST
 # variable "test_client_id" {
 #   description = "The client_id for the Keycloak client in Master Realm"


### PR DESCRIPTION
### Changes being made

Please include a short summary of the change.

### Context

What is the context for those changes? For example: particular role needs to be shown in token. Reference Azure Board task, if applicable.

### Quality Check

- [ ] Client has Name and Description defined.
- [ ] Full Scope Allowed is disabled.
- [ ] Direct Access Grants Enabled is disabled.
- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [ ] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] [CMDB](https://servicenow.justice.gov.bc.ca/cmdbuildProd/ui/#classes/Application/cards) is updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
