### PR TITLE
JAG RCC Front End

### DIFF
--- a/common-sso-dev/realms/isb/clients.tf
+++ b/common-sso-dev/realms/isb/clients.tf
@@ -67,6 +67,10 @@ module "JAM-POR" {
   source           = "./clients/jam-por"
   client_auth_pass = var.client_auth_pass
 }
+module "JAM-RCC-AUTHN" {
+  source           = "./clients/jam-rcc-authn"
+  client_auth_pass = var.client_auth_pass
+}
 module "ORDS-TOMCAT-CLIENT" {
   source = "./clients/tomcat-client"
 }

--- a/common-sso-dev/realms/isb/clients/jam-rcc-authn/main.tf
+++ b/common-sso-dev/realms/isb/clients/jam-rcc-authn/main.tf
@@ -1,0 +1,93 @@
+
+
+resource "keycloak_openid_client" "CLIENT" {
+  access_token_lifespan               = ""
+  access_type                         = "PUBLIC"
+  backchannel_logout_session_required = true
+  base_url                            = ""
+  client_authenticator_type           = "client-secret"
+  client_id                           = "jam-rcc-authn"
+  consent_required                    = false
+  description                         = "Report to Crown Counsel Authn Client"
+  direct_access_grants_enabled        = false
+  enabled                             = true
+  frontchannel_logout_enabled         = true
+  full_scope_allowed                  = false
+  implicit_flow_enabled               = false
+  name                                = "jam-rcc-authn"
+  pkce_code_challenge_method          = ""
+  realm_id                            = "ISB"
+  service_accounts_enabled            = false
+  standard_flow_enabled               = true
+  use_refresh_tokens                  = true
+  valid_redirect_uris = [
+    "https://rcc-web-eb019f-dev.apps.emerald.devops.gov.bc.ca*",
+    "http://localhost:3000*"
+  ]
+  root_url = "https://rcc-web-eb019f-dev.apps.emerald.devops.gov.bc.ca"
+
+  web_origins = ["+"]
+
+  // use this to use the IDP stopper theme and assign idir as default scope
+
+  login_theme = "keycloak" //bcgov-idp-login
+
+  # authentication_flow_binding_overrides {
+  #   browser_id = "Idp Stopper"
+  # }
+}
+
+module "justin_claim" {
+  source           = "../../../../../modules/justin-claim-mapper"
+  realm_id         = keycloak_openid_client.CLIENT.realm_id
+  client_id        = keycloak_openid_client.CLIENT.id
+  mapper_name      = "justin-participant"
+  client_auth_pass = var.client_auth_pass
+  config = {
+    "remote.parameters.user.attributes" = "firstname&lastName&email",
+    # Additional config settings...
+  }
+}
+# resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+#   realm_id         = keycloak_openid_client.CLIENT.realm_id
+#   client_id        = keycloak_openid_client.CLIENT.id
+
+#   default_scopes = [
+#     "profile",
+#     "email",
+#     "roles",
+#     "web-origins",
+#     "idir"
+#   ]
+# }
+resource "keycloak_openid_user_attribute_protocol_mapper" "user_attribute_mapper" {
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  client_id = keycloak_openid_client.CLIENT.id
+  name      = "Part Id to Token"
+
+  user_attribute = "partId"
+  claim_name     = "partId"
+}
+
+module "client-roles" {
+  source    = "../../../../../modules/client-roles"
+  client_id = keycloak_openid_client.CLIENT.id
+  realm_id  = keycloak_openid_client.CLIENT.realm_id
+  roles = {
+    "agencyDetailGet" = {
+      "name" = "agencyDetailGet"
+    },
+    "agencyDutyTypeDelete" = {
+      "name" = "agencyDutyTypeDelete"
+    },
+    "agencyDutyTypeGet" = {
+      "name" = "agencyDutyTypeGet"
+    },
+    "agencyDutyTypeSave" = {
+      "name" = "agencyDutyTypeSave"
+    },
+    "particAssignmentGet" = {
+      "name" = "particAssignmentGet"
+    },
+  }
+}

--- a/common-sso-dev/realms/isb/clients/jam-rcc-authn/outputs.tf
+++ b/common-sso-dev/realms/isb/clients/jam-rcc-authn/outputs.tf
@@ -1,0 +1,3 @@
+output "CLIENT" {
+  value = keycloak_openid_client.CLIENT
+}

--- a/common-sso-dev/realms/isb/clients/jam-rcc-authn/variables.tf
+++ b/common-sso-dev/realms/isb/clients/jam-rcc-authn/variables.tf
@@ -1,0 +1,5 @@
+
+variable "client_auth_pass" {
+  description = "Client secret or password for client authentication"
+  type        = string
+}

--- a/common-sso-dev/realms/isb/clients/jam-rcc-authn/versions.tf
+++ b/common-sso-dev/realms/isb/clients/jam-rcc-authn/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = ">= 4.0.0"
+    }
+  }
+}


### PR DESCRIPTION
### Changes being made

Front End DIAM config for JAG-RCC

### Context

What is/are the context for these changes? For example: particular role needs to be shown in token, JSUTIN Claims etc ?. Reference JIRA Board task, if applicable.

### Quality Check

- [ ] Client has Name and Description defined.
- [ ] Full Scope Allowed is disabled.
- [ ] Direct Access Grants Enabled is disabled.
- [ ] Valid Redirect URIs are properly defined, or explanation for `*` (allow all) is provided.
- [ ] Web Origins are set to `+` instead of `*` to restrict the CORS origins.
- [ ] Client Scopes are not assigned to client, or explanation for doing so is provided. [^1]
- [ ] Client module and all references are defined in clients.tf in realm root folder. Same rule applies to other resources, like groups and realm roles.
- [ ] Terraform plan contains only my changes, or other developers are aware that their manual changes can be overridden. [^2]
- [ ] DIAM [JIRA](https://justice.gov.bc.ca/jira/projects/DIAM/issues/)  issue is created and/or updated, if applicable.
- [ ] When updating `composite roles` (eg. Realm roles) and `scope mapping` resources, remember to re-run the apply. [^3]

[^1]: Data transparency. Does the client you are creating have the permissions to pass/access all the Client Scope attributes in the token? For example `profile` scope includes user birthdate, which is used by BCSC, but other applications shouldn't necessarily have access to it.
[^2]:
    Keep in mind that sometimes Keycloak automatically adds properties to newly created resources. `terraform plan` will show them as changes made outside of Terraform. As long as those attributes are empty and do not interfere with existing configuration, they can be ignored. Here is example of one:
    ![Terraform](https://user-images.githubusercontent.com/52381251/236051457-cdf91ff2-adc1-4ec0-b648-bfbcd7c55198.png)

[^3]: Due to the terraform provider bug, updating/deleting one entry within the resource deletes all of them. Re-running the `apply` action will result in restoring the configuration to the desired state. Keep in mind, that `composite role` deletion will show up on the `terraform plan` output, on contrary to `scope mapping`.
